### PR TITLE
Cancel in progress workflow. Trigger only on PR

### DIFF
--- a/.github/workflows/run_build_unit_test.yaml
+++ b/.github/workflows/run_build_unit_test.yaml
@@ -1,12 +1,13 @@
 name: Build SDK and Unit Tests
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/run_e2e_tests.yaml
+++ b/.github/workflows/run_e2e_tests.yaml
@@ -1,12 +1,13 @@
 name: Build SDK and E2E Tests
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:


### PR DESCRIPTION
## Why
- No need to run the tests after merging to main

### How
- Tweak tests to run only on PR.
- Cancel if one run is in progress

### How Has This Been Tested?

### Checklist
